### PR TITLE
fix(bug): Check for correct `merged` property

### DIFF
--- a/lib/delete-merged-branch.js
+++ b/lib/delete-merged-branch.js
@@ -3,7 +3,7 @@ module.exports = async (context) => {
   const repo = context.payload.repository.name
   const ref = `heads/${context.payload.pull_request.head.ref}`
 
-  if (!context.payload.merged) {
+  if (!context.payload.pull_request.merged) {
     context.log.info(`PR was closed but not merged. Keeping ${owner}/${repo}/${ref}`)
     return
   }

--- a/test/lib/delete-merged-branch.test.js
+++ b/test/lib/delete-merged-branch.test.js
@@ -32,7 +32,7 @@ describe('deleteMergedBranch function', () => {
 
   describe('branch is merged', async () => {
     beforeEach(async () => {
-      context.payload.merged = true
+      context.payload.pull_request.merged = true
       await deleteMergedBranch(context)
     })
 
@@ -62,7 +62,7 @@ describe('deleteMergedBranch function', () => {
 
   describe('branch is NOT merged', () => {
     beforeEach(async () => {
-      context.payload.merged = false
+      context.payload.pull_request.merged = false
       await deleteMergedBranch(context)
     })
 


### PR DESCRIPTION
The merged property is nested in the pull_request object. We were checking the root of the payload instead. 