### PR TITLE
Fix: forks should not branch trigger deletion

### DIFF
--- a/lib/delete-merged-branch.js
+++ b/lib/delete-merged-branch.js
@@ -1,7 +1,15 @@
 module.exports = async (context) => {
+  const headRepoId = context.payload.pull_request.head.repo.id
+  const baseRepoId = context.payload.pull_request.base.repo.id
+
   const owner = context.payload.repository.owner.login
   const repo = context.payload.repository.name
   const ref = `heads/${context.payload.pull_request.head.ref}`
+
+  if (headRepoId !== baseRepoId) {
+    context.log.info(`Closing PR from fork. Keeping ${context.payload.pull_request.head.label}`)
+    return
+  }
 
   if (!context.payload.pull_request.merged) {
     context.log.info(`PR was closed but not merged. Keeping ${owner}/${repo}/${ref}`)

--- a/test/lib/delete-merged-branch.test.js
+++ b/test/lib/delete-merged-branch.test.js
@@ -30,6 +30,23 @@ describe('deleteMergedBranch function', () => {
     repo = payload.repository.name
   })
 
+  describe('branch is merged from fork', () => {
+    beforeEach(async () => {
+      context.payload.pull_request.base.repo.id = 200
+      context.payload.pull_request.head.repo.id = 100
+      context.payload.pull_request.head.label = 'foobar'
+      await deleteMergedBranch(context)
+    })
+
+    it('should log it didn\'t delete the branch', () => {
+      expect(context.log.info).toBeCalledWith(`Closing PR from fork. Keeping ${context.payload.pull_request.head.label}`)
+    })
+
+    it('should NOT call the deleteReference method', () => {
+      expect(context.github.gitdata.deleteReference).not.toHaveBeenCalled()
+    })
+  })
+
   describe('branch is merged', async () => {
     beforeEach(async () => {
       context.payload.pull_request.merged = true

--- a/test/lib/delete-merged-branch.test.js
+++ b/test/lib/delete-merged-branch.test.js
@@ -18,7 +18,7 @@ describe('deleteMergedBranch function', () => {
       event: {
         event: 'pull_request.closed'
       },
-      payload,
+      payload: JSON.parse(JSON.stringify(payload)), // Njeh...
       github: {
         gitdata: {
           deleteReference
@@ -34,7 +34,7 @@ describe('deleteMergedBranch function', () => {
     beforeEach(async () => {
       context.payload.pull_request.base.repo.id = 200
       context.payload.pull_request.head.repo.id = 100
-      context.payload.pull_request.head.label = 'foobar'
+      context.payload.pull_request.head.label = 'foo:bar'
       await deleteMergedBranch(context)
     })
 


### PR DESCRIPTION
Forks should not trigger branch deletion. 

This bug was introduced because the code didn't make a difference between PR's that came from a fork or the original repo. Then it grabbed the current repo name and the branch name of the fork. This could result in something like `<currentRepo>/master`. A merge of such a PR could trigger the delete event of the master branch where this app was installed. Not something we want.

Fixes #21 