### PR TITLE
Use probot-config instead of context.config

### DIFF
--- a/lib/delete-merged-branch.js
+++ b/lib/delete-merged-branch.js
@@ -1,5 +1,7 @@
+const getConfig = require('probot-config')
+
 module.exports = async (context) => {
-  const config = await context.config('delete-merged-branch-config.yml', { exclude: [] })
+  const config = await getConfig(context, 'delete-merged-branch-config.yml', { exclude: [] })
   const headRepoId = context.payload.pull_request.head.repo.id
   const baseRepoId = context.payload.pull_request.base.repo.id
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "semantic-release": "semantic-release"
   },
   "dependencies": {
-    "probot": "7.4.0"
+    "probot": "7.4.0",
+    "probot-config": "^1.0.0"
   },
   "devDependencies": {
     "codecov": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1392,6 +1392,10 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+deepmerge@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+
 default-require-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"
@@ -3452,7 +3456,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
-js-yaml@^3.11.0, js-yaml@^3.12.0, js-yaml@^3.7.0, js-yaml@^3.9.0, js-yaml@^3.9.1:
+js-yaml@^3.10.0, js-yaml@^3.11.0, js-yaml@^3.12.0, js-yaml@^3.7.0, js-yaml@^3.9.0, js-yaml@^3.9.1:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
@@ -5044,6 +5048,13 @@ private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
+probot-config@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/probot-config/-/probot-config-1.0.0.tgz#4da831672fd08dab26fc522b6aee0027095039d0"
+  dependencies:
+    deepmerge "^2.2.1"
+    js-yaml "^3.10.0"
+
 probot@7.4.0:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/probot/-/probot-7.4.0.tgz#96a70148e8a114bcba75fd1a261155a559916cc5"
@@ -5690,9 +5701,9 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-semantic-release@15.12.3:
-  version "15.12.3"
-  resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-15.12.3.tgz#9f7c5a8ac55624a6418e0bf95bf53c2030487c12"
+semantic-release@15.12.4:
+  version "15.12.4"
+  resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-15.12.4.tgz#d0f4c3649d01e2e29a9df5e4886bab869d75ef02"
   dependencies:
     "@semantic-release/commit-analyzer" "^6.1.0"
     "@semantic-release/error" "^2.2.0"


### PR DESCRIPTION
Looks like `context.config` is not the same as `probot-config`, because it doesn't allow organizations to have default config for all repositories.

We have a file in `.github` repository with this content:

```
exclude: 
  - master
  - production
```

but delete branch bot removes `master` branch after it is merged to `production` branch (it is a way that we do releases in most of our repos).

So, in this PR I replaced `context.config` to `probot-config` so it works with default organization config