### PR TITLE
fix: yarn install failing on eslint expected node engine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.11.0-alpine
+FROM node:10.16.0-alpine
 
 LABEL "com.github.actions.name"="Delete merged branch"
 LABEL "com.github.actions.description"="No more manually deleting merged branches, this lovely app does it for you."

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "standard": "13.1.0"
   },
   "engines": {
-    "node": ">= 8.3.0"
+    "node": ">= 10.13.0"
   },
   "jest": {
     "coverageDirectory": "./coverage/",


### PR DESCRIPTION
**Why**
yarn install failing when building the docker image (for example when running as action) with:
eslint@6.1.0: The engine "node" is incompatible with this module. Expected version "^8.10.0 || ^10.13.0 || >=11.10.1".

**Testing**
docker builds