### PR TITLE
feat: add on_base inclusion

### DIFF
--- a/lib/delete-merged-branch.js
+++ b/lib/delete-merged-branch.js
@@ -3,17 +3,25 @@ const shouldClosePrByDefault = () => {
 }
 
 module.exports = async (context) => {
-  const config = await context.config('delete-merged-branch-config.yml', { exclude: [], delete_closed_pr: shouldClosePrByDefault() })
+  const config = await context.config('delete-merged-branch-config.yml', { exclude: [], on_base: [], delete_closed_pr: shouldClosePrByDefault() })
   const headRepoId = context.payload.pull_request.head.repo.id
   const baseRepoId = context.payload.pull_request.base.repo.id
 
   const owner = context.payload.repository.owner.login
   const repo = context.payload.repository.name
   const branchName = context.payload.pull_request.head.ref
+  const baseBranchName = context.payload.pull_request.base.ref
+
   const ref = `heads/${branchName}`
 
   if (headRepoId !== baseRepoId) {
     context.log.info(`Closing PR from fork. Keeping ${context.payload.pull_request.head.label}`)
+    return
+  }
+
+  if (config.on_base && config.on_base.length > 0 &&
+      !config.on_base.some((rule) => new RegExp(`^${rule.split('*').join('.*')}$`).test(baseBranchName))) {
+    context.log.info(`Base does not match any 'on_base'. Keeping ${context.payload.pull_request.head.label}`)
     return
   }
 


### PR DESCRIPTION
Resolves #225.

- If no `on_base` is specified in `delete-merged-branch-config.yml` then everything operates normally (i.e., we delete branches as long as they are not explicitly excluded).
- If base is in `on_base` and head is not in `exclude` then we delete head.
- If base is in `on_base` and head is in `exclude` we do not delete head.
- If `on_base` is non-empty and base is not included, we do not delete head.